### PR TITLE
Fix teleportation and normalization in RW/PageRank

### DIFF
--- a/src/MuxVizPy/build.py
+++ b/src/MuxVizPy/build.py
@@ -317,7 +317,6 @@ def build_supra_transition_matrix_from_supra_adjacency_matrix(
     order = layers*nodes
     supra_strength = supra.sum(axis=1).flatten()
     disconnected_nodes = order - len(supra_strength.nonzero()[1])
-    in_layer_disconnected_count = 0
 
     if disconnected_nodes > 0:
         print(" #Trapping nodes (no outgoing-links): ",disconnected_nodes,"\n")
@@ -326,16 +325,8 @@ def build_supra_transition_matrix_from_supra_adjacency_matrix(
         supra_strength[0,np.array(supra_strength>0)[0]] = 1. / supra_strength[0,np.array(supra_strength>0)[0]]
         supra_strength = sps.diags(np.array(supra_strength)[0])
         supra_transition = supra_strength.dot(supra)
-
-    if Type == "pagerank":
-        alpha = 0.85
-    elif Type == "classical":
-        alpha = 1
-    else:
-        # all other types, i.e. diffusive | maxent | physical
-        alpha = 1
     
-    if (disconnected_nodes > 0):
+    if disconnected_nodes > 0:
         ids = np.where(supra_transition.sum(axis=1) == 0)[0]
 
         if Type == "pagerank":
@@ -346,10 +337,9 @@ def build_supra_transition_matrix_from_supra_adjacency_matrix(
             not_ids = np.delete(np.arange(len(supra_transition)), ids)
             supra_transition[0,not_ids] = alpha * supra_transition[0,not_ids] + (1-alpha)/order
             """
-            #supra_transition.setdiag(1)
+            supra_transition[:,ids] = 1./order
         if Type == "classical":
             print(" #Using self-loops for isolated nodes\n")
-            #supra_transition[:,ids] = 1./order
             supra_transition[ids,ids]=[1]*len(ids)
     else:
         supra_transition = supra_transition# + sps.coo_matrix(np.zeros(supra_transition.shape))*(1-alpha)/order

--- a/src/MuxVizPy/leading_eigenv_approx.py
+++ b/src/MuxVizPy/leading_eigenv_approx.py
@@ -10,7 +10,7 @@ import graph_tool.clustering as gtclust
 from typing import Optional, Union, List
 
 def leading_eigenv_approx(
-    A: sps.spmatrix, max_iter: int = 1000, tol: float = 1e-6, cval: Optional[float] = None
+    A: sps.spmatrix, max_iter: int = 1000, tol: float = 1e-6, cval: Optional[float] = None, alpha: float = 0.85
 ) -> List[Union[float, np.ndarray]]:
     """
     Approximates the leading eigenvalue and eigenvector of a modified matrix C = A + B,
@@ -26,6 +26,8 @@ def leading_eigenv_approx(
         Tolerance for convergence (Euclidean distance between iterates). Default is 1e-6.
     cval : float or None, optional
         Constant value to use for dense matrix B. If None, uses (1 - 0.85) / n.
+    alpha : float, optional
+        Damping factor for the power iteration. Default is 0.85.
 
     Returns
     -------
@@ -35,32 +37,35 @@ def leading_eigenv_approx(
         Corresponding normalized eigenvector.
     """
     # Initialize the starting vector x as a random vector
-    A=A*0.85
     n = A.shape[0]
     x = np.random.rand(n)
     if cval==None:
-        cval = (1-0.85)/(n)
-    else:
-        cval = cval/n
+        cval = (1 - alpha) / n
+
     # Iterate until convergence
     for i in range(max_iter):
-        # Compute y = (A + C) x
-        y = A@x + np.ones(n)*x.sum()*cval
+        # Compute y = (alpha * A + cval) x
+        y = alpha * (A @ x) + cval * np.ones(n) * x.sum()
 
         # Normalize y to obtain the new vector x
-        x_new = y / np.linalg.norm(y)
+        # x_new = y / np.linalg.norm(y) # L2 norm
+        x_new = y / y.sum() # L1 norm
 
         # Compute the change in x and check for convergence
         delta_x = np.linalg.norm(x_new - x)
         if delta_x < tol:
             #print("Reached convergence")
+            x = x_new
             break
 
         # Update x for the next iteration
         x = x_new
 
     # Compute the dominant eigenvalue and eigenvector
-    eigenvalue = x.T@A@x + (np.ones(x.shape)*x.sum()*cval).T @ x
+    # eigenvalue = x.T@A@x + (np.ones(x.shape)*x.sum()*cval).T @ x
+    num = alpha * (x @ (A @ x)) + cval * (x.sum() ** 2) 
+    den = x @ x
+    eigenvalue = num / den # Rayleigh quotient
     eigenvector = x
     
     return [eigenvalue, eigenvector]
@@ -95,16 +100,18 @@ def katz_eigenvalue_approx(
     ValueError
         If convergence fails or alpha > 1 / lambda_max.
     """
-    k1, _ = leading_eigenv_approx(A, cval=0)
+    # k1, _ = leading_eigenv_approx(A, cval=0)
+    lam_max = sps.linalg.eigs(A, k=1, which="LM", return_eigenvectors=False)[0]
+    k1 = float(np.abs(lam_max)) 
     if alpha==0:
         alpha = (1 / k1) - (1e-5 * (1 / k1))
     else:
-        if alpha>1/k1:
-            print("Warning: alpha > 1 / lambda_max — instability possible")
+        if alpha>=1/k1:
+            print("Warning: alpha >= 1 / lambda_max — instability possible")
     
     x = np.random.randn(A.shape[0])
     for i in range(max_iter):
-        x_new = alpha* A@x + np.ones(A.shape[0])
+        x_new = alpha * A@x + np.ones(A.shape[0])
         # Compute the change in x and check for convergence
         delta_x = np.linalg.norm(x_new - x)
         if delta_x < tol:
@@ -113,6 +120,6 @@ def katz_eigenvalue_approx(
         # Update x for the next iteration
         x = x_new
     # Estimate Rayleigh quotient (optional for Katz, but kept for consistency)
-    eigenvalue = x.T@A@x
+    eigenvalue = (x.T @ A @ x) / (x.T @ x)
     eigenvector = x
     return [eigenvalue, eigenvector]

--- a/src/MuxVizPy/versatility.py
+++ b/src/MuxVizPy/versatility.py
@@ -87,7 +87,7 @@ def get_multi_katz_centrality(supra: sps.spmatrix, layers: int, nodes: int, alph
     return centrality_vector
 
 
-def get_multi_RW_centrality(supra: sps.spmatrix, layers: int, nodes: int, Type: str = "classical", multilayer: bool = True):
+def get_multi_RW_centrality(supra: sps.spmatrix, layers: int, nodes: int, Type: str = "classical", multilayer: bool = True, alpha: float = 0.15):
     """
     Computes multilayer random walk centrality using eigenvectors of the supra-transition matrix.
 
@@ -103,6 +103,8 @@ def get_multi_RW_centrality(supra: sps.spmatrix, layers: int, nodes: int, Type: 
         Type of transition: "classical" or "pagerank". Default is "classical".
     multilayer : bool, optional
         If True, aggregates replica node scores.
+    alpha : float, optional
+        Damping factor for the power iteration. Default is 0.85.
 
     Returns
     -------
@@ -116,7 +118,7 @@ def get_multi_RW_centrality(supra: sps.spmatrix, layers: int, nodes: int, Type: 
         leading_eigenvector = tmp[1]
         leading_eigenvalue = tmp[0][0]
     elif Type=="pagerank":
-        leading_eigenvalue, leading_eigenvector = leading_eigenv_approx.leading_eigenv_approx(supra_transition)
+        leading_eigenvalue, leading_eigenvector = leading_eigenv_approx.leading_eigenv_approx(supra_transition, alpha=alpha)
 
     if abs(leading_eigenvalue - 1) > 1e-5:
         raise ValueError("GetRWOverallOccupationProbability: ERROR! Expected leading eigenvalue equal to 1, obtained", leading_eigenvalue, ". Aborting process.")


### PR DESCRIPTION
### Random Walk / PageRank
leading_eigenv_approx.leading_eigenv_approx
- Added teleportation parameter (damping factor) alpha
- Switched to L1 normalization (instead of L2)
- Updated eigenvalue calculation using the Rayleigh quotient (added division by x @ x)

build.build_supra_transition_matrix_from_supra_adjacency_matrix
- Removed unused parameters and conditions (alpha is assigned in leading_eigenv_approx)
- Fixed dangling-node assignment

versatility.get_multi_RW_centrality
- Added teleportation parameter (damping factor) alpha